### PR TITLE
feat: Faz `id` da `Entity` ser mutável

### DIFF
--- a/src/domain/entity.ts
+++ b/src/domain/entity.ts
@@ -2,5 +2,5 @@ import { EntityProperties } from './entity-properties'
 import { ObjectId } from './object-id'
 
 export abstract class Entity<TId = ObjectId> implements EntityProperties<TId> {
-  protected constructor(readonly id: TId) {}
+  protected constructor(public id: TId) {}
 }


### PR DESCRIPTION
Antes da `Entity` ser adicionada ao banco de dados, não há `id`
definido. Depois que o `id` é gerado, o ideal é alterar a instância da
`Entity` existente com o novo `id` ao invés de criar uma nova instância
da `Entity` com o `id` novo e correr o risco de acidentalmente usar a
instância antiga, sem o `id`.